### PR TITLE
Update slippery-chicken-edit.lsp

### DIFF
--- a/slippery-chicken-edit.lsp
+++ b/slippery-chicken-edit.lsp
@@ -6045,7 +6045,10 @@ RTHM-SEQ-BAR: time-sig: 2 (4 4), time-sig-given: T, bar-num: 4,
    sc-name
    :instrument-palette instrument-palette
    :ensemble `(((,player (,instrument :midi-channel 1))))
-   :set-palette '((1 ((c4))))
+   ;; DJR Tue 17 Jul 2018 11:21:15 BST
+   ;; enlarged set-palette so (bars-to-sc) will work with an 
+   ;; instrument that CANNOT play 'c4
+   :set-palette '((1 ((c4 d4 e4 f4 g4 a4 b4 c5))))
    :set-map '((1 (1)))
    :rthm-seq-palette '((1 ((((4 4) w)))))
    :rthm-seq-map `((1 ((,player (1)))))))


### PR DESCRIPTION
DJR Tue 17 Jul 2018 11:21:15 BST

line 6051

Enlarged set-palette of the sc object in (make-minimal-sc) so (bars-to-sc), which calls it, will not throw an error when called with an instrument that cannot play 'c4.