### PR TITLE
OSC-CALL: convert to string and back to parse multiple input formats

### DIFF
--- a/src/osc-sc-bsd.lsp
+++ b/src/osc-sc-bsd.lsp
@@ -82,7 +82,7 @@
 ;;; OSC. Listens on a given port and sends out on another. NB ip#s need to
 ;;; be in the format #(127 0 0 1) for now.
 
-(defun osc-call (listen-port send-ip send-port print input-as-one-string) 
+(defun osc-call (listen-port send-ip send-port print csound) 
   ;; (let ((buffer (make-sequence '(vector (unsigned-byte 8)) 512)))
   ;; MDE Mon Apr 11 11:15:47 2016 -- increased buffer size
   ;; MDE Tue Mar 31 15:07:24 2020 -- increased again
@@ -103,8 +103,8 @@
 	;; need this otherwise messages only get printed when we quit
         (finish-output t)
         (socket-receive +osc-sc-in-socket+ buffer nil)
-	;; LF 2024-10-19, added input-as-one-string argument and parsing
-	(let* ((oscuff (if input-as-one-string
+	;; LF 2024-10-19, added csound argument and parsing
+	(let* ((oscuff (if csound
 			   (parse-one-string-message (osc:decode-bundle buffer))
 			   (osc:decode-bundle buffer)))
 	       ;; here: check if there's an opening (

--- a/src/osc-sc-bsd.lsp
+++ b/src/osc-sc-bsd.lsp
@@ -65,11 +65,24 @@
         +osc-sc-out-socket+ nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;; LF 2024-10-19 added to keep osc-call clean
+;;; parse a message of style ("/osc-sc something (+ 1 1)")
+;;; => ("/osc-sc" "something" "(+" 1 "1")
+(defun parse-one-string-message (message)
+  (loop for i in (first (sc::string-to-list (sc::list-to-string message)))
+	collect (write-to-string i) into result
+	finally (progn (setf (first result) (format nil "(~a" (first result)))
+		       (setf (first (last result))
+			     (format nil "~a)" (first (last result))))
+		       (return result))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; The main function we call to process lisp code and other messages sent via
 ;;; OSC. Listens on a given port and sends out on another. NB ip#s need to
 ;;; be in the format #(127 0 0 1) for now.
 
-(defun osc-call (listen-port send-ip send-port print) 
+(defun osc-call (listen-port send-ip send-port print input-as-one-string) 
   ;; (let ((buffer (make-sequence '(vector (unsigned-byte 8)) 512)))
   ;; MDE Mon Apr 11 11:15:47 2016 -- increased buffer size
   ;; MDE Tue Mar 31 15:07:24 2020 -- increased again
@@ -90,16 +103,17 @@
 	;; need this otherwise messages only get printed when we quit
         (finish-output t)
         (socket-receive +osc-sc-in-socket+ buffer nil)
-	(let* ((tmp (first (sc::string-to-list
-			    (sc::list-to-string (osc:decode-bundle buffer)))))
-	       (oscuff (list (loop for i in tmp collect (write-to-string i))))
+	;; LF 2024-10-19, added input-as-one-string argument and parsing
+	(let* ((oscuff (if input-as-one-string
+			   (parse-one-string-message (osc:decode-bundle buffer))
+			   (osc:decode-bundle buffer)))
 	       ;; here: check if there's an opening (
                (soscuff 
                  (progn
-                   (unless (third (first oscuff))
+                   (unless (third oscuff)
                      (error "osc-sc::osc-call: Couldn't decode buffer: ~a"
                             buffer))
-                   (if (char= #\( (elt (third (first oscuff)) 0))
+                   (if (char= #\( (elt (third oscuff) 0))
                        'lisp
                        (read-from-string (third oscuff))))))
           (when print			; MDE Mon May 26 10:39:48 2014

--- a/src/osc-sc.lsp
+++ b/src/osc-sc.lsp
@@ -95,9 +95,9 @@
 ;;;    Default = #(127 0 0 1))
 ;;; - :send-port. The UDP port to send messages back out on. Default = 8091.
 ;;; - :print. Print messages as they arrive. Default = NIL.
-;;; - :input-as-one-string. Default = NIL, meaning incomming messages should
+;;; - :csound. Default = NIL, meaning incomming messages should
 ;;;   be formatted similar to ("/osc-sc" "something" "(+" 1 "1"). When set to T,
-;;;   messages can also have this format: ("/osc-sc something (+ 1 1)")
+;;;   messages can also have this format: ("/osc-sc something (+ 1 1)").
 ;;; 
 ;;; RETURN VALUE
 ;;; T
@@ -108,11 +108,10 @@
                  (send-ip #(127 0 0 1))
                  (print nil)
 		 (send-port 8091)
-		 input-as-one-string)
+		 csound)
 ;;; ****
-  ;; LF 2024-10-19, added input-as-one-string argument.
-  (sb-bsd-sockets::osc-call listen-port send-ip send-port print
-			    input-as-one-string))
+  ;; LF 2024-10-19, added csound argument.
+  (sb-bsd-sockets::osc-call listen-port send-ip send-port print csound))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/src/osc-sc.lsp
+++ b/src/osc-sc.lsp
@@ -95,6 +95,9 @@
 ;;;    Default = #(127 0 0 1))
 ;;; - :send-port. The UDP port to send messages back out on. Default = 8091.
 ;;; - :print. Print messages as they arrive. Default = NIL.
+;;; - :input-as-one-string. Default = NIL, meaning incomming messages should
+;;;   be formatted similar to ("/osc-sc" "something" "(+" 1 "1"). When set to T,
+;;;   messages can also have this format: ("/osc-sc something (+ 1 1)")
 ;;; 
 ;;; RETURN VALUE
 ;;; T
@@ -104,9 +107,12 @@
                  (listen-port 8090)
                  (send-ip #(127 0 0 1))
                  (print nil)
-                 (send-port 8091))
+		 (send-port 8091)
+		 input-as-one-string)
 ;;; ****
-  (sb-bsd-sockets::osc-call listen-port send-ip send-port print))
+  ;; LF 2024-10-19, added input-as-one-string argument.
+  (sb-bsd-sockets::osc-call listen-port send-ip send-port print
+			    input-as-one-string))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
I addressed an issue a fellow student encountered when working with Csound and SC. Csound sends messages as a single string, e.g., ("/osc-sc something (+ 1 1)"), unlike Max or Pure Data, which send messages like ("/osc-sc" "something" "(+" 1 "1").

To solve this, I implemented parsing that converts the single string message into a list, making both message formats consistent with the latter approach. This solution seems minimally invasive (as it doesn't change other code or add a keyword etc.). An alternative approach could be adding a keyword to osc-call to avoid the unnecessary parsing of "standard" messages (but adding difficulty for the user). What do you think?